### PR TITLE
Issue #5

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -152,8 +152,8 @@ endfunction
 " Define default highlights.
 "
 function! indent_guides#define_default_highlights()
-  exe 'hi IndentGuidesOdd  guibg=NONE ctermbg=NONE'
-  exe 'hi IndentGuidesEven guibg=NONE ctermbg=NONE'
+  exe 'hi default clear IndentGuidesOdd'
+  exe 'hi default clear IndentGuidesEven'
 endfunction
 
 "


### PR DESCRIPTION
I believe this fixes nathanaelkane/vim-indent-guides#5 by setting up the highlight groups only if they don't already exist.
