### PR TITLE
Add doc/tags to gitgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Doc/tags seem to contain autogenerated data, which should not be added to git.

I noticed this while using this plugin with pathogen and git submodules: the submodel is being marked as dirty.

If you add it to .gitignore the issue disappears.

Thanks
Lenni
