### PR TITLE
Add a global option to disable the default keymapping.

### DIFF
--- a/plugin/indent_guides.vim
+++ b/plugin/indent_guides.vim
@@ -55,7 +55,9 @@ call s:InitVariable('g:indent_guides_debug',                 0 )
 call s:InitVariable('g:indent_guides_space_guides',          1 )
 
 " Default mapping
-nmap <Leader>ig :IndentGuidesToggle<CR>
+if maparg('<Leader>ig', 'n') == ''
+  nmap <Leader>ig :IndentGuidesToggle<CR>
+endif
 
 " Auto commands
 augroup indent_guides


### PR DESCRIPTION
The global variable g:indent_guides_default_keymapping will be used to enable or disable the default keymapping.

I add this option because the default key mapping may conflict with some users' settings.
