### PR TITLE
Foreground color fix for special characters

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -102,8 +102,8 @@ function! indent_guides#basic_highlight_colors()
   let l:cterm_colors = (&g:background == 'dark') ? ['darkgrey', 'black'] : ['lightgrey', 'white']
   let l:gui_colors   = (&g:background == 'dark') ? ['grey15', 'grey30']  : ['grey70', 'grey85']
 
-  exe 'hi IndentGuidesEven guibg=' . l:gui_colors[0] . ' ctermbg=' . l:cterm_colors[0]
-  exe 'hi IndentGuidesOdd  guibg=' . l:gui_colors[1] . ' ctermbg=' . l:cterm_colors[1]
+  exe 'hi IndentGuidesEven guibg=' . l:gui_colors[0] . ' guifg=' . l:gui_colors[1] . ' ctermbg=' . l:cterm_colors[0] . ' ctermfg=' . l:cterm_colors[1]
+  exe 'hi IndentGuidesOdd  guibg=' . l:gui_colors[1] . ' guifg=' . l:gui_colors[0] . ' ctermbg=' . l:cterm_colors[1] . ' ctermfg=' . l:cterm_colors[0]
 endfunction
 
 "
@@ -134,8 +134,8 @@ function! indent_guides#gui_highlight_colors()
     let l:hi_even_bg = indent_guides#lighten_or_darken_color(l:hi_odd_bg)
 
     " define the new highlights
-    exe 'hi IndentGuidesOdd  guibg=' . l:hi_odd_bg
-    exe 'hi IndentGuidesEven guibg=' . l:hi_even_bg
+    exe 'hi IndentGuidesOdd  guibg=' . l:hi_odd_bg . ' guifg=' . l:hi_even_bg
+    exe 'hi IndentGuidesEven guibg=' . l:hi_even_bg . ' guifg=' . l:hi_odd_bg
   end
 endfunction
 


### PR DESCRIPTION
Hi,

I really like the plugin idea but in my vim setup I also mark indentation tabs and white-spaces with special characters using 'listchars' and 'conceallevel' options. As 'SpecialKey' & 'Conceal' overlap with vim-indent-guides color groups, the default colors are used for guifg and ctermfg. E.g. on dark themes these special characters become white. I did a fix that sets the foreground to adjacent background color. That way the special characters don't stand out too much but yet stay visible. Check out the screenshot, before and after the fix http://i48.tinypic.com/oiceg6.png
## 

Sergey
