### PR TITLE
New `g:indent_guides_soft_pattern` option

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -42,7 +42,7 @@ function! indent_guides#enable()
   for l:level in range(s:start_level, s:indent_levels)
     let l:group = 'IndentGuides' . ((l:level % 2 == 0) ? 'Even' : 'Odd')
     let l:column_start = (l:level - 1) * s:indent_size + 1
-    let l:soft_pattern = indent_guides#indent_highlight_pattern('\s', l:column_start, s:guide_size)
+    let l:soft_pattern = indent_guides#indent_highlight_pattern(g:indent_guides_soft_pattern, l:column_start, s:guide_size)
     let l:hard_pattern = indent_guides#indent_highlight_pattern('\t', l:column_start, s:indent_size)
 
     " define the higlight patterns and add to matches list

--- a/doc/indent_guides.txt
+++ b/doc/indent_guides.txt
@@ -141,6 +141,16 @@ Default: 1. Values: 0 or 1.
 >
   let g:indent_guides_space_guides = 0
 <
+
+------------------------------------------------------------------------------
+                                                  *'indent_guides_soft_pattern'*
+Use this option to explicitly specify a pattern for indentation. For example
+to match spaces only in the beginning of line use ' ' pattern.
+
+Default: '\s'. Values: vim regexp.
+>
+  let g:indent_guides_soft_pattern = ' '
+<
 ------------------------------------------------------------------------------
                                          *'indent_guides_enable_on_vim_startup'*
 Use this option to control whether the plugin is enabled on Vim startup.

--- a/plugin/indent_guides.vim
+++ b/plugin/indent_guides.vim
@@ -53,6 +53,8 @@ call s:InitVariable('g:indent_guides_start_level',           1 )
 call s:InitVariable('g:indent_guides_enable_on_vim_startup', 0 )
 call s:InitVariable('g:indent_guides_debug',                 0 )
 call s:InitVariable('g:indent_guides_space_guides',          1 )
+call s:InitVariable('g:indent_guides_soft_pattern',        '\s')
+
 
 " Default mapping
 if !hasmapto('<Plug>IndentGuidesToggle', 'n') && maparg('<Leader>ig', 'n') == ''


### PR DESCRIPTION
I added a new option to explicitly specify a pattern for indentation. For example it allows to use spaces for alignment by matching them in the beginning of line and ignore them after tabs. The new option doesn't brake anything and back compatible with older versions of the plugin. Check out the screenshot.

![screen](https://f.cloud.github.com/assets/717109/1607653/9e5bf068-5496-11e3-8692-70c555bae580.png)
