### PR TITLE
Add option g:indent_guides_default_mapping

### DIFF
--- a/doc/indent_guides.txt
+++ b/doc/indent_guides.txt
@@ -168,6 +168,14 @@ map it to other keys. For example:
   :nmap <silent> <Leader>ig <Plug>IndentGuidesToggle
 <
 
+The plugin will not provide the default mapping if either:
+  * You already have something mapped to <Plug>IndentGuidesToggle.
+  * You are already using the <Leader>ig key sequence.
+  * You set to 0 the variable g:indent_guides_default_mapping:
+>
+  let g:indent_guides_default_mapping=0
+<
+
 You can also map some other commands that are not mapped by default. For
 example:
 >

--- a/plugin/indent_guides.vim
+++ b/plugin/indent_guides.vim
@@ -53,6 +53,7 @@ call s:InitVariable('g:indent_guides_start_level',           1 )
 call s:InitVariable('g:indent_guides_enable_on_vim_startup', 0 )
 call s:InitVariable('g:indent_guides_debug',                 0 )
 call s:InitVariable('g:indent_guides_space_guides',          1 )
+call s:InitVariable('g:indent_guides_default_mapping',       1 )
 
 if !exists('g:indent_guides_exclude_filetypes')
   let g:indent_guides_exclude_filetypes = ['help']
@@ -60,6 +61,7 @@ endif
 
 " Default mapping
 if !hasmapto('<Plug>IndentGuidesToggle', 'n') && maparg('<Leader>ig', 'n') == ''
+    \ && g:indent_guides_default_mapping != 0
   nmap <silent><unique> <Leader>ig <Plug>IndentGuidesToggle
 endif
 


### PR DESCRIPTION
Hi.

Thanks for writing this plugin! :)

I just made this little change to not provide any mapping by default, since the checks that were in place already are not enough. If one loads plugins before mappings the first check is not useful, and if one maps something to <leader>i, both <leader>i and <leader>ig work, but the first with an annoying delay.

Thank you.
