### PR TITLE
Fix issue 61

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -19,7 +19,7 @@ endfunction
 " other buffers and windows.
 "
 function! indent_guides#process_autocmds()
-  if g:indent_guides_autocmds_enabled
+  if exists('b:indent_guides_autocmds_enabled') && b:indent_guides_autocmds_enabled
     call indent_guides#enable()
   else
     call indent_guides#disable()
@@ -31,7 +31,7 @@ endfunction
 " entering it.
 "
 function! indent_guides#enable()
-  let g:indent_guides_autocmds_enabled = 1
+  let b:indent_guides_autocmds_enabled = 1
 
   if &diff || indent_guides#exclude_filetype()
     call indent_guides#clear_matches()
@@ -63,7 +63,7 @@ endfunction
 " entering it.
 "
 function! indent_guides#disable()
-  let g:indent_guides_autocmds_enabled = 0
+  let b:indent_guides_autocmds_enabled = 0
   call indent_guides#clear_matches()
 endfunction
 

--- a/plugin/indent_guides.vim
+++ b/plugin/indent_guides.vim
@@ -39,7 +39,7 @@ function s:InitVariable(var, value)
 endfunction
 
 " Fixed global variables
-let g:indent_guides_autocmds_enabled         = 0
+let b:indent_guides_autocmds_enabled         = 0
 let g:indent_guides_color_hex_pattern        = '#[0-9A-Fa-f]\{6\}'
 let g:indent_guides_color_hex_guibg_pattern  = 'guibg=\zs' . g:indent_guides_color_hex_pattern . '\ze'
 let g:indent_guides_color_name_guibg_pattern = "guibg='\\?\\zs[0-9A-Za-z ]\\+\\ze'\\?"


### PR DESCRIPTION
— make g:indent_guides_autocmds_enabled a buffer variable
— this allows file type auto commands like (autocmd FileType python IndentGuidesEnable)
