### PR TITLE
Fix s:hi_normal initialization

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -185,7 +185,7 @@ function! indent_guides#init_script_vars()
   let s:hi_normal   = indent_guides#capture_highlight('Normal')
 
   " remove 'font=<value>' from the s:hi_normal string (only seems to happen on Vim startup in Windows)
-  let s:hi_normal = substitute(s:hi_normal, ' font=[A-Za-z0-9:]\+', "", "")
+  let s:hi_normal = substitute(s:hi_normal, ' font=[A-Za-z0-9: ]\+', "", "")
 
   " shortcuts to the global variables - this makes the code easier to read
   let s:debug             = g:indent_guides_debug


### PR DESCRIPTION
Some schema has `font=Monospaced 10`, but because the regexp doesn't include a space, the 10 will hang around and break the color name -> hex conversion.
Just added a space.

This will resolve issue #67 
