### PR TITLE
Process autocmds when sw, et or ts option changes

### DIFF
--- a/plugin/indent_guides.vim
+++ b/plugin/indent_guides.vim
@@ -86,6 +86,9 @@ augroup indent_guides
   endif
 
   autocmd BufEnter,WinEnter,FileType * call indent_guides#process_autocmds()
+  if (v:version == 704 && has('patch786')) || (v:version > 704)
+    autocmd OptionSet tabstop,shiftwidth,expandtab call indent_guides#process_autocmds()
+  endif
 
   " Trigger BufEnter and process modelines.
   autocmd ColorScheme * doautocmd indent_guides BufEnter


### PR DESCRIPTION
The autocmd is only enabled on vim newer than 7.4.786 where the OptionSet
autocmd feature was introduced.