### PR TITLE
adapt termguicolors

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -100,7 +100,7 @@ endfunction
 "
 function! indent_guides#highlight_colors() abort
   if s:auto_colors
-    if has('gui_running') || has('nvim')
+    if has('gui_running') || has('nvim') || has('termguicolors')
       call indent_guides#gui_highlight_colors()
     else
       call indent_guides#basic_highlight_colors()


### PR DESCRIPTION
```
'termguicolors' 'tgc'	boolean (default off)
			global
			{not available when compiled without the
			|+termguicolors| feature}
	When on, uses |highlight-guifg| and |highlight-guibg| attributes in
	the terminal (thus using 24-bit color).

	Requires a ISO-8613-3 compatible terminal.  If setting this option
	does not work (produces a colorless UI) reading |xterm-true-color|
	might help.

	For Win32 console, Windows 10 version 1703 (Creators Update) or later
	is required. Use this check to find out:
		if has('vcon')
	This requires Vim to be built with the |+vtp| feature.

	Note that the "cterm" attributes are still used, not the "gui" ones.
	NOTE: This option is reset when 'compatible' is set.
```