### PR TITLE
fix: Use basic colors when termguicolors is off

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -100,7 +100,7 @@ endfunction
 "
 function! indent_guides#highlight_colors() abort
   if s:auto_colors
-    if has('gui_running') || has('nvim') || has('termguicolors')
+    if has('gui_running') || has('nvim') || (has('termguicolors') && &termguicolors)
       call indent_guides#gui_highlight_colors()
     else
       call indent_guides#basic_highlight_colors()


### PR DESCRIPTION
`indent_guides#gui_highlight_colors` only sets `guifg`/`guibg` and we don't want that when `termguicolors` is off.

Fixes: 3a4f7a6b9967 ("feat: Enable adaption of colors from termguicolors (#143)")
