### PR TITLE
[#154] avoid `execute()` in `capture_highlight`

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -250,11 +250,13 @@ endfunction
 " Captures and returns the output of highlight group definitions.
 "
 " Example: indent_guides#capture_highlight('normal')
-" Returns: 'Normal xxx guifg=#323232 guibg=#ffffff'
+" Returns: 'Normal fg=#323232 bg=#ffffff'
 "
 function! indent_guides#capture_highlight(group_name) abort
-  let l:output = execute('hi ' . a:group_name, 'silent')
-  let l:output = substitute(l:output, '\n', '', '')
+  let l:syn_id = synIDtrans(hlID(a:group_name))
+  let l:output = synIDattr(l:syn_id, 'name')
+  let l:output .= ' fg=' . synIDattr(l:syn_id, 'fg')
+  let l:output .= ' bg=' . synIDattr(l:syn_id, 'bg')
   return l:output
 endfunction
 


### PR DESCRIPTION
Instead of using `execute()` to get the foreground and background colours of a colour scheme, use [`synIDattr()`][1] and related functions. This prevents an E12 error when using this plugin in neovim to edit a file which has a [modeline][2].

Tested in neovim 0.9.0 and vim 8.2.

[1]: https://vimhelp.org/builtin.txt.html#synIDattr%28%29
[2]: https://vimhelp.org/options.txt.html#modeline

Closes #154 